### PR TITLE
Layers branch

### DIFF
--- a/public/geolocations.js
+++ b/public/geolocations.js
@@ -272,7 +272,7 @@ var locations_shops = {
             },
             "geometry": {
                "type": "Point",
-               "coordinates": [-73.6804, 42.72957]
+               "coordinates": [-73.680647,42.729606]
            },
             "room": {
                 "hours": {

--- a/public/geolocations.js
+++ b/public/geolocations.js
@@ -214,3 +214,199 @@ Locations:
     Rugby Field
     H-Building
 */
+
+var locations_shops = {
+    "type": "FeatureCollection",
+    "features": [
+        {
+            "type": "Feature",
+            "id": "jec_shop",
+            "properties": {
+                "name": "JEC Student Machines Shop",
+                "nick": "Processes Shop",
+                "description": "Machine Shop located in JEC",
+                "popupContent": "JEC Student Machines Shop"
+            },
+            "geometry": {
+               "type": "Point",
+               "coordinates": [-73.680042, 42.729716]
+           },
+            "room": {
+                "hours": {
+                    "mon":"9 a.m.-noon and 2-8 p.m.",
+                    "tues":"9 a.m.—noon and 1-7 p.m. ",
+                    "weds": "10 a.m.—1 p.m.  and 2-8 p.m.",
+                    "thurs":"9 a.m.—noon and 2-8 p.m.",
+                    "fri":"8-11 a.m. and noon-3 p.m.",
+                    "sat":"11 a.m. -3 p.m.,",
+                    "sun":"2-6 p.m."
+                },
+                "info": "All students who intend to use the machines in this room\n\
+                must pass the SOE Safety Test Rensselaer Manufacturing and Prototyping\n\
+                Laboratories-Safety Orientation listed on RPI HR Skillport Site. \n\
+                They must show proof of taking and passing the class to shop supervisors.\n\
+                Afterwards, all students are welcome to use the machines in the JEC Student Machines Shop.\n\
+                No prior knowledge of machining is required. However, it is recommended\n\
+                that students take Engineering Processes (ENGR 1300).",
+                "location": "Jonsson Engineering Center (JEC) 1010"
+            },
+            "contents": {
+                "machines": ["Haas TL 1 CNC Lathe", "Acer 3-Axis CNC Milling Machine",
+                    "Laguna Swift 4’x4’ CNC Router", "Thunder Mars90 100w laser Cutter",
+                    "Snap-on Sandblaster", "General Machining and Fabrication Equipment",
+                    "General Machining and Fabrication Equipment",
+                    "Metal and Plastic Forming and Shearing Equipment",
+                    "Steel and Plastic Welding Equipment" ],
+                "available_materials": "",
+                "equipment": ""
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "ied_shop",
+            "properties": {
+                "name": "Design Lab/IED Shop",
+                "nick": "IED Shop",
+                "description": "Machine Shop located in JEC",
+                "popupContent": "Design Lab/IED Shop"
+            },
+            "geometry": {
+               "type": "Point",
+               "coordinates": [-73.6804, 42.72957]
+           },
+            "room": {
+                "hours": {
+                    "mon":"9 am - 4 pm and 5-9 pm",
+                    "tues":"9 am - 4 pm and 5-9 pm",
+                    "weds":"9 am - 4 pm and 5-9 pm",
+                    "thurs":"9 am - 4 pm and 5-9 pm",
+                    "fri":"9 am - 4 pm and 5-7 pm",
+                    "sat":"",
+                    "sun":""
+                },
+                "info": "All students who intend to use the machines in this room\n\
+                must pass the SOE Safety Test Rensselaer Manufacturing and Prototyping\n\
+                Laboratories-Safety Orientation listed on RPI HR Skillport Site. \n\
+                They must show proof of taking and passing the class to shop supervisors.\n\
+                Afterwards, usage of machines is determined on case-by-case basis.\n\
+                Students are always welcome to see the shop supervisor to discuss their projects.",
+                "location": "Jonsson Engineering Center (JEC) Room 2332"
+            },
+            "contents": {
+                "machines": ["Haas CNC Control Simulators", "Haas Mini Mill", "Haas SL 10",
+                    "Haas Super VF 2", "Haas Tool Room Mill", "Mitutoyo Crysta-Plus M574 CMM",
+                    "Paint Booth", "General Machining and Fabrication Equipment",
+                    "Electronic Scopes and Meters"],
+                "available_materials": "",
+                "equipment": ""
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "forge_shop",
+            "properties": {
+                "name": "Maker Space: The Forge",
+                "nick": "The Forge",
+                "description": "Maker Space located in",
+                "popupContent": "Design Lab/IED Shop"
+            },
+            "geometry": {
+               "type": "Point",
+               "coordinates": [-73.678974, 42.729574]
+           },
+            "room": {
+                "hours": {
+                    "mon":"",
+                    "tues":"",
+                    "weds": "",
+                    "thurs":"",
+                    "fri":"",
+                    "sat":"",
+                    "sun":""
+                },
+                "info": "The Forge charges $10 per semester for students to gain access to\n\
+                all of the machines. Afterwards, students are charged $0.05/gram of filament\n\
+                for the 3D Printer and $0.50 per hour of light time for the laser cutter.",
+                "location": "George M. Low Center for Industrial Innovation (CII) Room 2037"
+            },
+            "contents": {
+                "machines": ["3D Scanners","Form 1+ 3D Printer","gCreate 3D Printer",
+                    "Laser Cutter","Makerbot Mini","Makerbot Z18’s","Prusa i3’s",
+                    "Sewing Machine","Taz 5","Taz Mini","Taz MOAR-Struder","Taz Quadfusion",
+                    "Vinyl Cutter"],
+                "available_materials": ["PLA", "ABS", "PETG"],
+                "equipment": ""
+            }
+        },
+        {
+            "type": "Feature",
+            "id": "mill_shop",
+            "properties": {
+                "name": "Manufacturing Innovation Learning Laboratory",
+                "nick": "The MILL",
+                "description": "Manufacturing/maching shop located in the CII.",
+                "popupContent": "Manufacturing Innovation Learning Laboratory"
+            },
+            "geometry": {
+               "type": "Point",
+               "coordinates": [-73.679208, 42.72975]
+           },
+            "room": {
+                "hours": {
+                    "mon":"",
+                    "tues":"",
+                    "weds": "",
+                    "thurs":"",
+                    "fri":"",
+                    "sat":"",
+                    "sun":""
+                },
+                "info": "All students who intend to use the machines in this room\n\
+                must pass the SOE Safety Test Rensselaer Manufacturing and Prototyping\n\
+                Laboratories-Safety Orientation listed on RPI HR Skillport Site. \n\
+                They must show proof of taking and passing the class to shop supervisors.\n\
+                Afterwards, usage of machines is determined on case-by-case basis.\n\
+                Students are always welcome to see the shop supervisor to discuss their projects.",
+                "location": "George M. Low Center for Industrial Innovation (CII) Room 1027"
+            },
+            "contents": {
+                "machines": ["Haas VF 1 – CNC Milling Machine",
+                    "Haas OM-2 CNC Milling Machine",
+                    "Moore Nanotechnology Systems 350 UPL Lathe",
+                    "Hurricane Laser Cutter Category 4 Charley 80W",
+                    "Adept Cobra 800 SCARA Robot",
+                    "SONY Conveyor System",
+                    "Staubli RX 90 Robot",
+                    "Fanuc LR Mate, with Vision, Robot Educational Training System",
+                    "Stratasys Dimension FDM Machine",
+                    "Stratasys UPrint FDM Machine",
+                    "Z-Corporation Z310 3D Printer",
+                    "B-9 Creator Stereolithography Printer",
+                    "Phenix Direct Metal Selective Laser Sintering 3D Printer",
+                    "Brown and Sharpe Gage 2000 CMM",
+                    "Faro Platinum Inspection Arm",
+                    "Arburg Allrounder 270c Injection Molder",
+                    "Arburg Allrounder 221k Injection Molder",
+                    "Battenfeld Injection Molder",
+                    "Formech 660 Vacuum Former",
+                    "Flow Mach2 Abrasive Water-Jet Cutter",
+                    "Sonitek S840 Ultrasonic Welder",
+                    "Sonitek TS500 Thermal Press",
+                    "Branson Ultrasonic Welder 2000 D",
+                    "Branson Ultrasonic Welder 2000 DT",
+                    "General Machining Equipment"],
+                "available_materials": [],
+                "equipment": ""
+            }
+        }
+    ]
+};
+
+/*
+Locations:
+JEC Student Machines Shop
+Design Lab/IED Shop
+Maker Space: The Forge
+Manufacturing Innovation Learning Laboratory
+*/
+

--- a/public/machine_sites.js
+++ b/public/machine_sites.js
@@ -12,7 +12,7 @@ module.exports = {
             },
             "geometry": {
                "type": "Point",
-               "coordinates": [-73.6804, 42.72957]
+               "coordinates": [-73.680042, 42.729716]
            },
             "room": {
                 "hours": {
@@ -132,7 +132,7 @@ module.exports = {
             },
             "geometry": {
                "type": "Point",
-               "coordinates": [-73.678974, 42.729574]
+               "coordinates": [-73.679208, 42.72975]
            },
             "room": {
                 "hours": {
@@ -190,4 +190,5 @@ Locations:
 JEC Student Machines Shop
 Design Lab/IED Shop
 Maker Space: The Forge
+Manufacturing Innovation Learning Laboratory
 */

--- a/public/map.js
+++ b/public/map.js
@@ -117,10 +117,14 @@ const onEachFeature = function(feature, layer) {
     }
 }
 
+//Array of circleMakers
+let locations_arr = [];
+let locations_shops_arr = [];
 
 /**
   * Style and add the points to the map
 */
+
 L.geoJSON(locations, {
     style: function (feature) {
         return feature.properties && feature.properties.style;
@@ -138,9 +142,11 @@ L.geoJSON(locations, {
             opacity: 1,
             fillOpacity: 0.8
         }
-        return L.circleMarker(latlng,campus_circle_settings);
+        locations_arr.push(L.circleMarker(latlng,campus_circle_settings));
+        return locations_arr[locations_arr.length-1];
     },
 }).addTo(mymap);
+
 
 L.geoJSON(locations_shops, {
     style: function (feature) {
@@ -160,14 +166,14 @@ L.geoJSON(locations_shops, {
             opacity: 1,
             fillOpacity: 0.8
         }
-        
-        return L.circleMarker(latlng, machine_circle_settings);
+        locations_shops_arr.push(L.circleMarker(latlng,machine_circle_settings));
+        return locations_shops_arr[locations_shops_arr.length-1];
     },
 }).addTo(mymap);
 
-//still need to figure out how to create layergroups!!
-const campus_locations_layer = L.layerGroup();
-const machine_locations_layer = L.layerGroup();
+
+let campus_locations_layer = L.layerGroup(locations_arr);
+let machine_locations_layer = L.layerGroup(locations_shops_arr);
 
 let overlayMaps = {
     "Campus Locations": campus_locations_layer,

--- a/public/map.js
+++ b/public/map.js
@@ -56,6 +56,8 @@ const campus = [
 ];
 L.polygon(campus, {color: 'gray', opacity: 0.1}).addTo(mymap);
 
+//test comment
+
 // Default popup object that would show on the map if a nonregistered point is clicked
 const popup = L.popup();
 

--- a/public/map.js
+++ b/public/map.js
@@ -13,30 +13,14 @@ https://leafletjs.com/reference-1.3.4.html#point
 for some reason according to the API**
 */
 
-
 /*
-Display the map on the page at id 'map'
-
-setView() focuses the map around the given point.
+Creates map and focuses the map around the given point.
 In this case, it does so on creation of the map (pageload)
-Usage: setView([latitude, longitude], zoomlevel)
 */
-//const mymap = L.map('mapContainer').setView([42.73131, -73.675218], 16);
-
-
-///work here next time
-const mymap = L.map('mapContainer', {
+let mymap = L.map('mapContainer', {
     center: [42.73131, -73.675218],
-    zoom: 16,
-    layers: []
-})
-/*
-var map = L.map('map', {
-    center: [39.73, -104.99],
-    zoom: 10,
-    layers: [grayscale, cities]
+    zoom: 16
 });
-*/
 
 /*
 Tile Layer is the display style (satellite, street, etc.)
@@ -70,8 +54,6 @@ const campus = [
    [42.728116, -73.684765]
 ];
 L.polygon(campus, {color: 'gray', opacity: 0.1}).addTo(mymap);
-
-//test comment
 
 // Default popup object that would show on the map if a nonregistered point is clicked
 const popup = L.popup();
@@ -129,17 +111,24 @@ const onEachFeature = function(feature, layer) {
     }
 }
 
-
-
-/**
-  * Style and add the points to the map
+/*
+this line broke it for some reason? is it because its nodejs?
+const machine_sites = require('./public/machine_sites.js');
+const machine_locations_layer = L.layerGroup(machine_locations);
 */
+
+/*
+/**
+  * Style and add the points to the correct layer
+*/
+const campus_locations_layer = L.layerGroup();
+
 L.geoJSON(locations, {
     style: function (feature) {
         return feature.properties && feature.properties.style;
     },
     // For each feature added to the map, it will perform the onEachFeature() function
-    onEachFeature: onEachFeature,
+    onEachFeature: onEachFeature(feature, campus_locations_layer),
 
     // Adds a circleMarker at the point specified by the coords of the feature
     pointToLayer: function (feature, latlng) {
@@ -152,4 +141,14 @@ L.geoJSON(locations, {
             fillOpacity: 0.8
         });
     }
-}).addTo(mymap);
+})
+
+// variable holding all non-base layers
+let overlayMaps = {
+    //"Machine sites": machine_locations_layer
+    "Campus locations": campus_locations_layer
+    // add more additional layers here
+};
+
+// Adding the non-base layers to the map
+L.control.layers(null, overlayMaps).addTo(mymap);

--- a/public/map.js
+++ b/public/map.js
@@ -21,7 +21,22 @@ setView() focuses the map around the given point.
 In this case, it does so on creation of the map (pageload)
 Usage: setView([latitude, longitude], zoomlevel)
 */
-const mymap = L.map('mapContainer').setView([42.73131, -73.675218], 16);
+//const mymap = L.map('mapContainer').setView([42.73131, -73.675218], 16);
+
+
+///work here next time
+const mymap = L.map('mapContainer', {
+    center: [42.73131, -73.675218],
+    zoom: 16,
+    layers: []
+})
+/*
+var map = L.map('map', {
+    center: [39.73, -104.99],
+    zoom: 10,
+    layers: [grayscale, cities]
+});
+*/
 
 /*
 Tile Layer is the display style (satellite, street, etc.)
@@ -113,6 +128,8 @@ const onEachFeature = function(feature, layer) {
         layer.bindPopup(newPopupContent);
     }
 }
+
+
 
 /**
   * Style and add the points to the map

--- a/public/map.js
+++ b/public/map.js
@@ -13,14 +13,20 @@ https://leafletjs.com/reference-1.3.4.html#point
 for some reason according to the API**
 */
 
+
 /*
-Creates map and focuses the map around the given point.
+Display the map on the page at id 'map'
+
+setView() focuses the map around the given point.
 In this case, it does so on creation of the map (pageload)
+Usage: setView([latitude, longitude], zoomlevel)
 */
+
 let mymap = L.map('mapContainer', {
     center: [42.73131, -73.675218],
-    zoom: 16
-});
+    zoom: 16,
+    layers: []
+})
 
 /*
 Tile Layer is the display style (satellite, street, etc.)
@@ -111,44 +117,62 @@ const onEachFeature = function(feature, layer) {
     }
 }
 
-/*
-this line broke it for some reason? is it because its nodejs?
-const machine_sites = require('./public/machine_sites.js');
-const machine_locations_layer = L.layerGroup(machine_locations);
-*/
 
-/*
 /**
-  * Style and add the points to the correct layer
+  * Style and add the points to the map
 */
-const campus_locations_layer = L.layerGroup();
-
 L.geoJSON(locations, {
     style: function (feature) {
         return feature.properties && feature.properties.style;
     },
     // For each feature added to the map, it will perform the onEachFeature() function
-    onEachFeature: onEachFeature(feature, campus_locations_layer),
+    onEachFeature: onEachFeature,
 
     // Adds a circleMarker at the point specified by the coords of the feature
     pointToLayer: function (feature, latlng) {
-        return L.circleMarker(latlng, { // circleMarker shows at the Point's location
+        const campus_circle_settings = { 
             radius: 8,
             fillColor: "#ff7800",
             color: "#000",
             weight: 1,
             opacity: 1,
             fillOpacity: 0.8
-        });
-    }
-})
+        }
+        return L.circleMarker(latlng,campus_circle_settings);
+    },
+}).addTo(mymap);
 
-// variable holding all non-base layers
+L.geoJSON(locations_shops, {
+    style: function (feature) {
+        return feature.properties && feature.properties.style;
+    },
+    // For each feature added to the map, it will perform the onEachFeature() function
+    onEachFeature: onEachFeature,
+
+    // Adds a circleMarker at the point specified by the coords of the feature
+    pointToLayer: function (feature, latlng) {
+        const machine_circle_settings = { 
+            // circleMarker shows at the Point's location
+            radius: 8,
+            fillColor: "#0000ff",
+            color: "#000",
+            weight: 1,
+            opacity: 1,
+            fillOpacity: 0.8
+        }
+        
+        return L.circleMarker(latlng, machine_circle_settings);
+    },
+}).addTo(mymap);
+
+//still need to figure out how to create layergroups!!
+const campus_locations_layer = L.layerGroup();
+const machine_locations_layer = L.layerGroup();
+
 let overlayMaps = {
-    //"Machine sites": machine_locations_layer
-    "Campus locations": campus_locations_layer
-    // add more additional layers here
+    "Campus Locations": campus_locations_layer,
+    "Machine Shop Locations": machine_locations_layer
 };
 
-// Adding the non-base layers to the map
 L.control.layers(null, overlayMaps).addTo(mymap);
+

--- a/public/map.js
+++ b/public/map.js
@@ -145,8 +145,7 @@ L.geoJSON(locations, {
         locations_arr.push(L.circleMarker(latlng,campus_circle_settings));
         return locations_arr[locations_arr.length-1];
     },
-}).addTo(mymap);
-
+});
 
 L.geoJSON(locations_shops, {
     style: function (feature) {
@@ -169,7 +168,7 @@ L.geoJSON(locations_shops, {
         locations_shops_arr.push(L.circleMarker(latlng,machine_circle_settings));
         return locations_shops_arr[locations_shops_arr.length-1];
     },
-}).addTo(mymap);
+});
 
 
 let campus_locations_layer = L.layerGroup(locations_arr);

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const options = {useNewUrlParser: true};
 
 /* ================================= SERVER START ==================================== */
 const port = process.env.PORT;
-console.log(user, pass);
+
 MongoClient.connect(uri, options, function(err, db) {
   if (err) {
     throw err;
@@ -33,8 +33,7 @@ MongoClient.connect(uri, options, function(err, db) {
     console.log("Database connected in route '/'!");
     let dbo = db.db("forgemill");
 
-    /* Populate Database with locations if need be (ONLY FOR USERS WITH WRITE ACCESS).*/
-
+    /* Populate Database with locations if need be (ONLY FOR USERS WITH WRITE ACCESS).
     console.log(locations);
     dbo.collection("locations").insertMany(locations.features, {ordered: false})
     .then(function(success) {
@@ -43,6 +42,7 @@ MongoClient.connect(uri, options, function(err, db) {
     .catch(function(err) {
       console.error("ERROR:", err);
     });
+    */
 
     // Download initial location data from database before starting server
     dbo.collection('locations').find().toArray()
@@ -54,12 +54,13 @@ MongoClient.connect(uri, options, function(err, db) {
       // Start server after initial database connection
       app.listen(port);
       console.log('Listening on port ' + port);
+      db.close();
     })
     .catch(function(err) {
       if (err) throw err;
     });
 
-    db.close();
+    
   }
 });
 /* =================================================================================== */


### PR DESCRIPTION
Added campus points layer and machine shops layer to the map. Now, when viewing the map page, default view has no locations on map. When you add filters from the map key in the top right hand corner, points are added to the map. 

When adding additional layergroups (for example frats or academic buildings), create new layer groups, then add them to the overlayers element at the bottom of map.js. All elements in overlayers are added automatically. 