### PR TITLE
search_sens (fix)

### DIFF
--- a/scripts/routes/user.js
+++ b/scripts/routes/user.js
@@ -109,7 +109,8 @@ router.get('/search', jsonParser, (req, res) => {
   console.log(query);
   
   
-  if(req.query["query"]== null || req.query["query"]== ''){
+  // Display all location results if search with no query 
+  if(query["query"]== null || query["query"]== ''){
     Location.find()
     .then(results => {
       /*results.forEach(element => {
@@ -122,8 +123,28 @@ router.get('/search', jsonParser, (req, res) => {
     });
   }
   else{
-    Location.find({
-      _id: query["query"]
+    Location.find({ 
+      // Find case insensitive query matches based on id, name, or nickname
+      $or: [
+        {
+          _id: { 
+            $regex: query["query"], 
+            $options: "i" 
+          }
+        },
+        {
+          "properties.name": { 
+            $regex: query["query"], 
+            $options: "i" 
+          }
+        },
+        {
+          "properties.nick": { 
+            $regex: query["query"], 
+            $options: "i"
+          }
+        }
+      ]
     })
     .then(results => {
       res.render('searchResults', { page_name: "Search", layout: "layout2.ejs", extractStyles: true, results: results, results_count: results.length});


### PR DESCRIPTION
## Description
Allows user searches to to be case insensitive and match similar location id's, names, or nicknames even if an incomplete name is searched.

Fixes #99

## Solution
Implemented regex with i option to allow for case insensitive query matching with id's, names, or nicknames of locations in the database.

## Known Issues
None

## Testing Procedures
Search location names. 

## Checklist for author
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if any)
- [ ] My changes generate no new warnings
