### PR TITLE
Added missing locations to map

### DIFF
--- a/campusmap.sql
+++ b/campusmap.sql
@@ -108,6 +108,7 @@ INSERT INTO `images` (`location`, `link`) VALUES
 ('Nugent Hall', 'http://www.rpi.edu/dept/cct/apps/reslife/images/pictures/nugent1.jpg'),
 ('Experimental Media and Performing Arts Center at Rensselaer', 'http://empac.rpi.edu/sites/default/files/styles/empac_cms_slideshow__default/public/ESTO_AaronEsto_50.jpg?itok=9rVzDof9');
 
+
 -- --------------------------------------------------------
 
 --
@@ -130,14 +131,19 @@ INSERT INTO `main` (`location`, `description`, `address`, `phone`) VALUES
 ('Academy Hall', 'Home to the Student Health Center, Bursar, and registrar. This building also includes an auditorium.', '110 8th St, Troy, NY 12180', 518),
 ('Admissions', 'This is where the admissions department is located at RPI.', '110 8th St, Troy, NY 12180', 518),
 ('Amos Eaton Hall', 'Home of the Mathematics Department and part of the Computer Science Department. Many Math and Computer science courses are taught inside. It is names after Amos Eaton, Co-Founder of RPI.', 'Amos Eaton Hall, 110 8th Street, Troy, NY, 12180', NULL),
+('Anderson Field', 'Sports field on campus. Many other sports play here besides rugby', 'Sage Ave, Troy, NY 12180', NULL),
 ('Barton Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
 ('Blitman Commons', 'Campus residence hall. Includes various ammenities such as a dining hall.', '1800 6th Ave, Troy, NY 12180', NULL),
 ('Bray Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
+('Cary Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
 ('Carnegie Building', 'Academic building on campus.', '110 8th St, Troy, NY 12180', NULL),
 ('Center for Biotechnology and Interdisciplinary Studies', 'Research facility on campus. This is a popular destination for guest speakers on campus.', '1623 15th St, Troy, NY 12180', 518),
 ('Cogswell Laboratory', 'A chemistry-biology research center on campus. Recieves government funding from the National Science Foundation as well as the New York State Dormitory Authority.', '110 8th St, Troy, NY 12180', NULL),
 ('Commons Dining Hall', 'One of the main dining hills on campus. Located on freshman hill. The mailing center is also located in this building.', '1999 Burdett Ave, Troy, NY 12180', 518),
+('Crockett Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
 ('Darrin Communications Center', 'Main lecture hall on campus. Also where the CCPD has their office. This is the building where most large lectures are held.', '110 8th Street, Troy, NY, 12180', NULL),
+('Davison Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
+('E-Complex', 'One of the residence halls on campus. Located on Sage Ave.', '110 8th St, Troy, NY 12180', NULL),
 ('Experimental Media and Performing Arts Center at Rensselaer', 'Alot of extracurricular activities happen here. The building includes a 1,200 seat concert hall and a 400 seat theater.', '44 8th St, Troy, NY 12180', 518),
 ('Folsom Library', 'The main library on campus. 4 floors of study spaces, bookshelves and even a cafe. A great place to study quietly.', '110 8th St, Troy, NY 12180', NULL),
 ('Greene Building', 'Academic building on campus. Home to the School of Architecture.', '110 8th St, Troy, NY 12180', NULL),
@@ -150,12 +156,13 @@ INSERT INTO `main` (`location`, `description`, `address`, `phone`) VALUES
 ('Low Center for Industrial Innovation', 'Commonly known as the CII. Acadmic building on campus that has a number of larger academic buildings and auditoriums.', '110 8th St, Troy, NY 12180', NULL),
 ('Mueller Center', 'Fitness and wellness center on campus. This building has a gym that extends for two floors with various yoga and wellness classes offered on the third floor. This building also includes the armory and the campus swimming pools.', '110 8th St, Troy, NY 12180', 518),
 ('Nason Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
+('North Hall', 'One of the residence halls on campus. Located on Sage Ave.', '110 8th St, Troy, NY 12180', NULL),
 ('Nugent Hall', 'One of the residence halls on campus. Located on freshman hill.', '1999 Burdett Ave, Troy, NY 12180', NULL),
 ('Pittsburgh Building', 'Academic building on campus. Home of the Lally School of Management.', '110 8th St, Troy, NY 12180', 518),
 ('Public Safety', 'Home to the campus police.', '110 8th St, Troy, NY 12180', NULL),
 ('Rensselaer Union', 'Home to a number of different recreation centers, food courts, study rooms, and the campus store.', '110 8th St, Troy, NY 12180', 518),
 ('Rickets Building', 'Academic building on campus. Home to the Chemical Engineering Department.', '110 8th St, Troy, NY 12180', NULL),
-('Rugby Field', 'Sports field on campus. Many other sports play here besides rugby', 'Sage Ave, Troy, NY 12180', NULL),
+('Robinson Field', 'Sports field on campus. Mainly used for baseball', 'Eagle St, Troy, NY 12180', NULL),
 ('Russell Sage Laboratory', 'Academic building on campus. Home of the School of Humanities, Arts, and Social Sciences.', '110 8th St, Troy, NY 12180', NULL),
 ('Sage Dining Hall', 'One of the main dining halls on campus', '110 8th St, Troy, NY 12180', NULL),
 ('Sigma Phi Epsilon', 'Worst frat on campus, don\'t join!', '2005 15th St, Troy, NY 12180', NULL),

--- a/scripts/routes/geolocations.js
+++ b/scripts/routes/geolocations.js
@@ -1218,6 +1218,86 @@ var locations = {
         'type': 'Point',
         'coordinates': [-73.677091, 42.732331]
       }
+    },
+    {
+      'type': 'Feature',
+      '_id': 'cary',
+      'id': 'cary',
+      'properties': {
+        'name': 'Cary Hall',
+        'nick': 'Cary, Freshman Five, Freshman Hill',
+        'category': 'Student Housing',
+        'description': 'One of five identical housing buildings in the \'Freshman Five\'',
+        'popupContent': 'Cary Hall'
+      },
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-73.67459, 42.728845]
+      }
+    },
+    {
+      'type': 'Feature',
+      '_id': 'davison',
+      'id': 'davison',
+      'properties': {
+        'name': 'Davison Hall',
+        'nick': 'Davison',
+        'category': 'Student Housing',
+        'description': 'Residence Hall',
+        'popupContent': 'Davison Hall'
+      },
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-73.674021, 42.727277]
+      }
+    },
+    {
+      'type': 'Feature',
+      '_id': 'crockett',
+      'id': 'crockett',
+      'properties': {
+        'name': 'Crockett Hall',
+        'nick': 'Crockett',
+        'category': 'Student Housing',
+        'description': 'Freshman Five Residence Hall',
+        'popupContent': 'Crockett Hall'
+      },
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-73.673421, 42.728285]
+      }
+    },
+    {
+      'type': 'Feature',
+      '_id': 'robinson',
+      'id': 'robinson',
+      'properties': {
+        'name': 'Robinson Field',
+        'nick': 'Baseball Field',
+        'category': 'Student Life',
+        'description': 'Used for baseball practice',
+        'popupContent': 'Robinson Field'
+      },
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-73.672997, 42.735666]
+      }
+    },
+    {
+      'type': 'Feature',
+      '_id': 'ecomplex',
+      'id': 'ecomplex',
+      'properties': {
+        'name': 'E-Complex',
+        'nick': 'E-Complex',
+        'category': 'Student Housing',
+        'description': 'Residence Hall',
+        'popupContent': 'E-Complex'
+      },
+      'geometry': {
+        'type': 'Point',
+        'coordinates': [-73.679182, 42.731394]
+      }
     }
   ]
 };
@@ -1260,6 +1340,7 @@ Mueller Center
 Playhouse
 Radio Club W2SZ
 Rensselaer Union
+Robinson Field
 Robison Swimming Pool
 Russell Sage Dining Hall
 
@@ -1269,7 +1350,11 @@ Blitman Commons
 Bray Hall
 Bryckwyck
 Burdett Avenue Residence Hall
+Cary Hall
 Colonie Apartments
+Crockett Hall
+Davison Hall
+E-Complex
 Hall Hall
 Nason Hall
 North Hall


### PR DESCRIPTION
## Description
Missing locations in geolocations.js have been added along with placeholder descriptions for each in campusmap.sql. These additions will not impact the ongoing merge from dev to master significantly.

Fixes #108

## Solution
I figured out which places on campus were not on the map yet and added them to geolocations.js and campusmap.sql.

## Known Issues
None

## Testing Procedures
Run the app and find the new locations added:
Cary Hall
Davison Hall
Crockett Hall
E-Complex
Robinson Field
North Hall

## Checklist for author
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if any)
- [X] My changes generate no new warnings
