### PR TITLE
Remove machine locations layer and show campus locations by default

### DIFF
--- a/public/map.js
+++ b/public/map.js
@@ -179,19 +179,5 @@ L.geoJSON(locations_shops, {
   },
 });
 
-
-/* Creating layer groups to hold arrays of locations
-*  These layer groups will be added to the map, and will be represented by
-*  the map keys. The maps keys filter which dots are shown on the map.
-*/
-let campus_locations_layer = L.layerGroup(locations_arr);
-let machine_locations_layer = L.layerGroup(locations_shops_arr);
-
-let overlayMaps = {
-  'Campus Locations': campus_locations_layer,
-  'Machine Shop Locations': machine_locations_layer
-  // add more layer groups here
-};
-
-// adding the layer groups in overlayMaps to the map (but it doesn't render yet)
-L.control.layers(null, overlayMaps).addTo(mymap);
+// Add the campus location points to the map (will automatically display when map is opened)
+let campus_locations_layer = L.layerGroup(locations_arr).addTo(mymap);


### PR DESCRIPTION
## Description
Fixes issues 125 and 90; because machine maps is being separated from campus maps, this removes the option of displaying the machine locations layer and makes the locations show automatically when the map opens (for simplicity and ease of use).

Fixes #125 and #90

## Solution
Removed the code implementing map keys for the machine and campus location layers and changed it to automatically add just the campus locations layer to the map.

## Known Issues
N/A

## Testing Procedures
View the home screen of the map when starting the app, coming back from browse, etc.

## Checklist for author
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if any)
- [ ] My changes generate no new warnings
