### PR TITLE
Fix Location schema to move non-Feature members into '.properties'

### DIFF
--- a/api/src/controllers/info.ts
+++ b/api/src/controllers/info.ts
@@ -44,7 +44,7 @@ const readComments = (req: Request, res: Response): void => {
 
   /** Return all comments for matching location id */
   Mongoose.connect(uri, options).then(() => {
-    Location.findOne({ id }, { comments: 1 }).then((result) => {
+    Location.findOne({ id }, { id: 1, properties: 1 }).then((result) => {
       console.log('\tFound', result);
       Mongoose.disconnect();
       res.json(result);
@@ -71,7 +71,7 @@ const readPhotos = (req: Request, res: Response): void => {
 
   /** Return all photos for matching location id */
   Mongoose.connect(uri, options).then(() => {
-    Location.findOne({ id }, { photos: 1 }).then((result) => {
+    Location.findOne({ id }, { id: 1, properties: 1 }).then((result) => {
       console.log('\tFound', result);
       Mongoose.disconnect();
       res.json(result);

--- a/api/src/controllers/locations.ts
+++ b/api/src/controllers/locations.ts
@@ -19,7 +19,7 @@ const readIndex = (req: Request, res: Response): void => {
   console.log('GET: /api/locations');
   // Use Mongoose to get all location in the database
   Mongoose.connect(uri, options).then(() => {
-    Location.find({}, { type: 1, properties: 1, geometry: 1, _id: 0 })
+    Location.find({}, { _id: 0 })
       .then((locations: MongooseDocument[]) => {
         Mongoose.disconnect();
         res.json(locations);

--- a/api/src/controllers/search.ts
+++ b/api/src/controllers/search.ts
@@ -37,7 +37,7 @@ const readIndex = (req: Request, res: Response): void => {
     : {};
 
   Mongoose.connect(uri, options).then(() => {
-    Location.find(searchQuery, { properties: 1 }).then((results) => {
+    Location.find(searchQuery, { _id: 0, id: 1, properties: 1 }).then((results) => {
       console.log(`\tFound ${results.length} locations.`);
       Mongoose.disconnect();
       res.json(results);

--- a/api/src/models/Location.ts
+++ b/api/src/models/Location.ts
@@ -39,14 +39,18 @@ const LocationSchema = new mongoose.Schema({
       type: String,
       require: true,
     },
-  },
-  comments: {
-    type: Array,
-    require: true,
-  },
-  photos: {
-    type: Array,
-    require: true,
+    thumbnail: {
+      type: String,
+      require: true,
+    },
+    comments: {
+      type: Array,
+      require: true,
+    },
+    photos: {
+      type: Array,
+      require: true,
+    },
   },
   geometry: {
     type: {

--- a/campusmap/src/search-results/SearchResult/SearchResult.tsx
+++ b/campusmap/src/search-results/SearchResult/SearchResult.tsx
@@ -14,8 +14,7 @@ interface Props {
  * Individual Search Result component rendered as a card.
  */
 const SearchResult = ({ location }: Props): ReactElement => (
-  // eslint-disable-next-line no-underscore-dangle
-  <Link to={`/info?loc=${location._id}`}>
+  <Link to={`/info?loc=${location.id}`}>
     <Card className="mb-4">
       <Row className="p-4">
         <Col className="col-2">

--- a/campusmap/src/search-results/SearchResultsPage.tsx
+++ b/campusmap/src/search-results/SearchResultsPage.tsx
@@ -24,8 +24,7 @@ const SearchResultsPage = (): ReactElement => {
       </h5>
       {loading && <ProgressBar animated variant="danger" now={100} />}
       {data && data.map((location) => (
-        // eslint-disable-next-line no-underscore-dangle
-        <SearchResult location={location} key={location._id} />
+        <SearchResult location={location} key={location.id} />
       ))}
       {data && !data.length && <p>No results found.</p>}
     </Container>

--- a/campusmap/src/types/interfaces.d.ts
+++ b/campusmap/src/types/interfaces.d.ts
@@ -21,15 +21,14 @@ export interface LocationProperties {
   popupContent: string;
   thumbnail: string;
   amenity?: string;
+  comments?: Comment[];
+  photos?: Photo[];
 }
 
 export interface Location extends Feature {
-  _id: string;
   id: string;
   properties: LocationProperties;
   geometry: Point;
-  comments?: Comment[];
-  photos?: Photo[];
 }
 
 export interface User {


### PR DESCRIPTION
## Description
The `Location` schema was defined incorrectly to be used with GeoJSON `Feature` types before, and this fixes that. There was also the issue that the frontend was using the `_id` field to populate some urls, and it would come up as `undefined` since we should be using the `id` property instead.

Fixes #145 

## Solution
The interface and the model schema are now both defined based on the [official IETF definition](https://tools.ietf.org/html/rfc7946#section-3.2) of a GeoJSON Feature. I also changed any use of `._id` to `.id` on the frontend to make sure we always get the right property.

## Known Issues
There are no known issues at this time. Changing the database schema should not break anything since there are no documents in the database right now that have `Comments` or `Photos`.

## Testing Procedures
* Use the review app to ensure all functionality remains in areas that were changed.
* Search the frontend code for any remaining use of `._id`

## Checklist for author
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
