### PR TITLE
Implement the Not Found Page in React

### DIFF
--- a/campusmap/src/app/App.tsx
+++ b/campusmap/src/app/App.tsx
@@ -3,9 +3,9 @@ import { ReactElement } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import MapPage from 'campusmap/src/map';
+import NotFoundPage from 'campusmap/src/not-found';
 import SearchResultsPage from 'campusmap/src/search-results';
 import InfoPage from 'campusmap/src/info';
-import NotFoundPage from 'campusmap/src/not-found';
 
 import Header from './Header';
 import Footer from './Footer';

--- a/campusmap/src/not-found/NotFoundPage.tsx
+++ b/campusmap/src/not-found/NotFoundPage.tsx
@@ -1,30 +1,31 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import { ListGroup, Jumbotron } from 'react-bootstrap';
+import { Container } from 'react-bootstrap';
 
 /**
  * NotFoundPage element that specifies next steps when a page is not found.
  */
 const NotFoundPage = (): ReactElement => (
-  <Jumbotron>
+  <Container className="my-4">
     <h1>
       We couldn&apos;t find the page you were looking for&nbsp;
       <span role="img" aria-label="sad face">😢</span>
     </h1>
+    <br />
     <p>The URL may have been mistyped or the page may have moved:</p>
-    <ListGroup>
-      <ListGroup.Item>
+    <ul>
+      <li>
         Please try navigating back to the <Link to="/">homepage</Link> to find what you are looking for.
-      </ListGroup.Item>
-      <ListGroup.Item>
+      </li>
+      <li>
         Alternatively you can&nbsp;
         <a href="https://github.com/gaskij/rpicampusmap/issues/new" target="blank" rel="noopener noreferrer">
           report a suspected issue.
         </a>
-      </ListGroup.Item>
-    </ListGroup>
-  </Jumbotron>
+      </li>
+    </ul>
+  </Container>
 );
 
 export default NotFoundPage;

--- a/campusmap/src/not-found/NotFoundPage.tsx
+++ b/campusmap/src/not-found/NotFoundPage.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { ListGroup, Jumbotron } from 'react-bootstrap';
 
 /**
- * NotFoundPage element that specifies next steps for a not found page.
+ * NotFoundPage element that specifies next steps when a page is not found.
  */
 const NotFoundPage = (): ReactElement => (
   <Jumbotron>


### PR DESCRIPTION
## Description
The remade not found page was not consistent with the original page, so this implementation of the not found page was made to be more consistent with the original
Fixes #143 

## Solution

- Changed the Jumbotron to an Alert so that the background could be changed to white, matching the background of the site.

- Changed the Listgroup to a bulleted list

## Known Issues
There are no known issues right now. 

## Testing Procedures

- Navigate to the Not Found page and ensure that it loads properly.

## Checklist for author

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
