### PR TITLE
Update TileLayer creation to new Mapbox standard

### DIFF
--- a/campusmap/package-lock.json
+++ b/campusmap/package-lock.json
@@ -6365,9 +6365,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.1.0",
@@ -8394,9 +8394,9 @@
       }
     },
     "leaflet": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.6.0.tgz",
-      "integrity": "sha512-CPkhyqWUKZKFJ6K8umN5/D2wrJ2+/8UIpXppY7QDnUZW5bZL5+SEI2J7GBpwh4LIupOKqbNSQXgqmrEJopHVNQ=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
+      "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
     },
     "leaflet-defaulticon-compatibility": {
       "version": "0.1.1",

--- a/campusmap/package.json
+++ b/campusmap/package.json
@@ -50,7 +50,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "jquery": "^3.5.1",
-    "leaflet": "^1.6.0",
+    "leaflet": "^1.7.1",
     "leaflet-defaulticon-compatibility": "^0.1.1",
     "popper.js": "^1.16.1",
     "react": "^16.13.1",

--- a/campusmap/src/map/leaflet/map.ts
+++ b/campusmap/src/map/leaflet/map.ts
@@ -19,12 +19,15 @@ const createLeafletMap = (targetId: string): L.Map => {
    * Set the tile layer to be used for the map.
    * This uses and accredits OpenStreetMap and Mapbox for the tile layers.
    */
-  L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw', {
+  L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token={accessToken}', {
     maxZoom: 18,
     attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, '
           + '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, '
           + 'Imagery &copy; <a href="https://www.mapbox.com/">Mapbox</a>',
-    id: 'mapbox.streets',
+    id: 'mapbox/streets-v11',
+    tileSize: 512,
+    zoomOffset: -1,
+    accessToken: 'pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4NXVycTA2emYycXBndHRqcmZ3N3gifQ.rJcFIG214AriISLbB6B5aw',
   }).addTo(campusMap);
 
   /** Show a popup when the map is clicked that alerts the coordinates of the clicked spot. */


### PR DESCRIPTION
## Description
The tiles requested from Mapbox were not being fulfilled, since the API has deprecated that method of request. This resulted in empty gray tiles being shown on the map, instead of the actual streets and buildings. More info [on the Mapbox blog](https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4).

## Solution
Updated the `TileLayer` in `map.ts` to use the new style provided. This changes the look of the map, using the new tiles.

## Known Issues
No known issues

## Testing Procedures
Open the test deployment below and ensure the map renders properly with the new tiles.

## Checklist for author
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
