### PR TITLE
Remove latlong from production

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,6 +31,12 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+      
+      - name: Create env file
+        run: |
+          touch .env
+          echo NODE_ENV=production >> .env
+          cat .env
 
       - name: Install Dependencies
         run: npm run install-ui

--- a/campusmap/src/map/leaflet/map.ts
+++ b/campusmap/src/map/leaflet/map.ts
@@ -32,7 +32,10 @@ const createLeafletMap = (targetId: string): L.Map => {
 
   /** Show a popup when the map is clicked that alerts the coordinates of the clicked spot. */
   const popup = L.popup();
-  campusMap.on('click', (e: L.LeafletMouseEvent) => onMapClick(e, popup, campusMap));
+  if (process.env.NODE_ENV === 'development') {
+    campusMap.on('click', (e: L.LeafletMouseEvent) => onMapClick(e, popup, campusMap));
+  }
+
 
   /** Outline the area of the campus on the map with a gray translucency. */
   L.polygon(campusArea, { color: 'gray', opacity: 0.1 }).addTo(campusMap);

--- a/campusmap/webpack.config.js
+++ b/campusmap/webpack.config.js
@@ -1,66 +1,82 @@
 const path = require('path');
+const webpack = require('webpack');
+const dotenv = require('dotenv');
+
 const CleanWebpackPlugin = require('clean-webpack-plugin').CleanWebpackPlugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.exports = {
-  mode: 'development',
-  devtool: 'inline-source-map',
-  entry: './src/index.tsx',
-  plugins: [
-    new CleanWebpackPlugin({
-      verbose: true,
-      cleanOnceBeforeBuildPatterns: ['dist/webpack'],
-    }),
-    new HtmlWebpackPlugin({
-      title: 'RPI CampusMap',
-      template: './public/index.html',
-      favicon: './public/favicon.ico',
-    }),
-  ],
-  module: {
-    rules: [
-      {
-        test: /\.(tsx|ts|jsx|js)$/,
-        use: 'babel-loader',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.css$/,
-        use: ['style-loader', 'css-loader'],
-      },
-      {
-        test: /\.(png|jp(e*)g|svg|ico)$/,
-        use: ['url-loader?limit=100000'],
-      },
-      {
-        test: /\.html$/,
-        use: [
-          {
-            loader: 'html-loader',
-            options: {
-              minimize: true,
-            },
-          },
-        ],
-      },
+
+module.exports = () => {
+  // call dotenv and it will return an Object with a parsed key 
+  const env = dotenv.config({path: path.join(__dirname, '../.env')}).parsed;
+
+  // reduce it to a nice object, the same as before
+  const envKeys = Object.keys(env).reduce((prev, next) => {
+    prev[`process.env.${next}`] = JSON.stringify(env[next]);
+    return prev;
+  }, {});
+
+  return {
+    mode: 'development',
+    devtool: 'inline-source-map',
+    entry: './src/index.tsx',
+    plugins: [
+      new CleanWebpackPlugin({
+        verbose: true,
+        cleanOnceBeforeBuildPatterns: ['dist/webpack'],
+      }),
+      new HtmlWebpackPlugin({
+        title: 'RPI CampusMap',
+        template: './public/index.html',
+        favicon: './public/favicon.ico',
+      }),
+      new webpack.DefinePlugin(envKeys)
     ],
-  },
-  resolve: {
-    extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
-    alias: {
-      campusmap: path.resolve(__dirname),
+    module: {
+      rules: [
+        {
+          test: /\.(tsx|ts|jsx|js)$/,
+          use: 'babel-loader',
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader'],
+        },
+        {
+          test: /\.(png|jp(e*)g|svg|ico)$/,
+          use: ['url-loader?limit=100000'],
+        },
+        {
+          test: /\.html$/,
+          use: [
+            {
+              loader: 'html-loader',
+              options: {
+                minimize: true,
+              },
+            },
+          ],
+        },
+      ],
     },
-  },
-  output: {
-    filename: 'campusmap.bundle.js',
-    path: path.resolve(__dirname, 'dist/webpack'),
-    publicPath: '/',
-  },
-  devServer: {
-    contentBase: path.join(__dirname, 'dist/webpack'),
-    port: 3000,
-    public: 'http://localhost:3000',
-    historyApiFallback: true,
-    proxy: { "/api/**": { target: 'http://localhost:5000', secure: false }  },
+    resolve: {
+      extensions: ['.ts', '.tsx', '.js', '.jsx', '.json'],
+      alias: {
+        campusmap: path.resolve(__dirname),
+      },
+    },
+    output: {
+      filename: 'campusmap.bundle.js',
+      path: path.resolve(__dirname, 'dist/webpack'),
+      publicPath: '/',
+    },
+    devServer: {
+      contentBase: path.join(__dirname, 'dist/webpack'),
+      port: 3000,
+      public: 'http://localhost:3000',
+      historyApiFallback: true,
+      proxy: { "/api/**": { target: 'http://localhost:5000', secure: false }  },
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "build": "cd api && npm run build && cd ../campusmap && npm run build",
+    "heroku-prebuild": "touch .env && echo \"NODE_ENV=production\" >> .env",
     "heroku-postbuild": "npm run install-all && npm run build",
     "install-all": "cd api && npm install && cd ../campusmap && npm install",
     "install-api": "cd api && npm install",
@@ -14,6 +15,9 @@
     "test-api": "cd api && npm run test-coverage",
     "test-ui": "cd campusmap && npm run test-coverage",
     "start": "cd api && npm run api-prod"
+  },
+  "engines": {
+    "node": "14.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
deleted the lat long function on mapbox to only show on dev mode and added to webpack to handle envkeys

## Description
Remove latitude and longitude markers from the map in production but still works in dev.

Fixes #155 

## Solution
I added an if statement to identify the env it was in and had to update webpack config to do that in the front end.

## Known Issues
No known issues.

## Testing Procedures
Deploy the test below to check dev v prod.

## Checklist for author
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
