### PR TITLE
Add logout capability!

### DIFF
--- a/api/src/cas/controller.ts
+++ b/api/src/cas/controller.ts
@@ -30,7 +30,7 @@ CASAuthentication.prototype.logout = function logoutOverride(req: any, res: Resp
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 /** Instantiate CASAuthentication */
-const cas = new CASAuthentication({
+export const cas = new CASAuthentication({
   /* eslint-disable @typescript-eslint/camelcase */
   cas_url: 'https://cas-auth.rpi.edu/cas',
   service_url: process.env.NODE_ENV === 'production' ? 'https://rpicampusmap.herokuapp.com' : 'http://localhost:3000',
@@ -76,7 +76,6 @@ const readCasLogout = (req: Request, res: Response): void => {
   } catch (err) {
     res.status(500).send(`ERROR: ${err}`);
   }
-  
 };
 
 export const CasAPIController: CRUDController = {
@@ -106,5 +105,3 @@ export const CasLogoutController: CRUDController = {
   update: unsupported,
   delete: unsupported,
 };
-
-export default cas;

--- a/api/src/cas/controller.ts
+++ b/api/src/cas/controller.ts
@@ -28,11 +28,19 @@ const readCasUser = (req: Request, res: Response): void => {
   try {
     if (req.session) {
       if (req.session.casUser) {
-        res.json(req.session.casUser);
+        res.json({ casUser: req.session.casUser, admin: false });
       } else {
         res.json('Not authenticated');
       }
     }
+  } catch (err) {
+    res.status(500).send(`ERROR: ${err}`);
+  }
+};
+
+const readCasLogout = (req: Request, res: Response): void => {
+  try {
+    res.json({ casUser: 'Not authenticated', admin: false });
   } catch (err) {
     res.status(500).send(`ERROR: ${err}`);
   }
@@ -61,7 +69,7 @@ export const CasAuthController: CRUDController = {
 
 export const CasLogoutController: CRUDController = {
   create: unsupported,
-  read: unsupported,
+  read: readCasLogout,
   update: unsupported,
   delete: unsupported,
 };

--- a/api/src/cas/controller.ts
+++ b/api/src/cas/controller.ts
@@ -16,7 +16,7 @@ const readCasAPI = (req: Request, res: Response): void => {
       if (req.session.casUser) {
         res.json(req.session);
       } else {
-        res.json('Not authenticated');
+        res.json({ casUser: 'Not authenticated', admin: false });
       }
     }
   } catch (err) {
@@ -30,7 +30,7 @@ const readCasUser = (req: Request, res: Response): void => {
       if (req.session.casUser) {
         res.json({ casUser: req.session.casUser, admin: false });
       } else {
-        res.json('Not authenticated');
+        res.json({ casUser: 'Not authenticated', admin: false });
       }
     }
   } catch (err) {

--- a/api/src/cas/controller.ts
+++ b/api/src/cas/controller.ts
@@ -2,9 +2,41 @@
 
 /** Node Imports */
 import { Request, Response } from 'express';
+import CASAuthentication from 'express-cas-authentication';
 
 /** Type Imports */
 import { CRUDController } from '../types/interfaces';
+
+// Override the default CASAuthentication Logout function.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+CASAuthentication.prototype.logout = function logoutOverride(req: any, res: Response): void {
+  // Destroy the entire session if the option is set.
+  if (this.destroy_session) {
+    req.session.destroy((err: any) => {
+      if (err) {
+        /* eslint-disable-next-line no-console */
+        console.log(err);
+      }
+    });
+  } else { // Otherwise, just destroy the CAS session variables.
+    delete req.session[this.session_name];
+    if (this.session_info) {
+      delete req.session[this.session_info];
+    }
+  }
+  // Redirect the client back to the page the request was sent from. **OVERRIDE**
+  res.redirect('back');
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+/** Instantiate CASAuthentication */
+const cas = new CASAuthentication({
+  /* eslint-disable @typescript-eslint/camelcase */
+  cas_url: 'https://cas-auth.rpi.edu/cas',
+  service_url: process.env.NODE_ENV === 'production' ? 'https://rpicampusmap.herokuapp.com' : 'http://localhost:3000',
+  session_name: 'casUser',
+  /* eslint-enable @typescript-eslint/camelcase */
+});
 
 const unsupported = (req: Request, res: Response): void => {
   res.send('This method is not supported.');
@@ -44,6 +76,7 @@ const readCasLogout = (req: Request, res: Response): void => {
   } catch (err) {
     res.status(500).send(`ERROR: ${err}`);
   }
+  
 };
 
 export const CasAPIController: CRUDController = {
@@ -73,3 +106,5 @@ export const CasLogoutController: CRUDController = {
   update: unsupported,
   delete: unsupported,
 };
+
+export default cas;

--- a/api/src/cas/route.ts
+++ b/api/src/cas/route.ts
@@ -46,7 +46,7 @@ router.route('/authenticate')
 
 /** Redirect unauthenticated clients */
 router.route('/logout')
-  .get(cas.logout)
+  .get(cas.logout, (req, res) => CasLogoutController.read(req, res))
   .post(jsonParser, (req, res) => CasLogoutController.create(req, res))
   .put((req, res) => CasLogoutController.update(req, res))
   .delete((req, res) => CasLogoutController.delete(req, res));

--- a/api/src/cas/route.ts
+++ b/api/src/cas/route.ts
@@ -1,7 +1,6 @@
 /** Node Imports */
 import express, { Response } from 'express';
 import bodyParser from 'body-parser';
-import CASAuthentication from 'express-cas-authentication';
 
 /** Custom Imports */
 import {
@@ -11,36 +10,7 @@ import {
   CasLogoutController,
 } from './controller';
 
-// Override the default CASAuthentication Logout function.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-CASAuthentication.prototype.logout = function logoutOverride(req: any, res: Response): void {
-  // Destroy the entire session if the option is set.
-  if (this.destroy_session) {
-    req.session.destroy((err: any) => {
-      if (err) {
-        /* eslint-disable-next-line no-console */
-        console.log(err);
-      }
-    });
-  } else { // Otherwise, just destroy the CAS session variables.
-    delete req.session[this.session_name];
-    if (this.session_info) {
-      delete req.session[this.session_info];
-    }
-  }
-  // Redirect the client back to the page the request was sent from. **OVERRIDE**
-  res.redirect('back');
-};
-/* eslint-enable @typescript-eslint/no-explicit-any */
-
-/** Instantiate CASAuthentication */
-const cas = new CASAuthentication({
-  /* eslint-disable @typescript-eslint/camelcase */
-  cas_url: 'https://cas-auth.rpi.edu/cas',
-  service_url: process.env.NODE_ENV === 'production' ? 'https://rpicampusmap.herokuapp.com' : 'http://localhost:3000',
-  session_name: 'casUser',
-  /* eslint-enable @typescript-eslint/camelcase */
-});
+import cas from './controller'
 
 const jsonParser = bodyParser.json();
 const router = express.Router();

--- a/api/src/cas/route.ts
+++ b/api/src/cas/route.ts
@@ -1,5 +1,5 @@
 /** Node Imports */
-import express from 'express';
+import express, { Response } from 'express';
 import bodyParser from 'body-parser';
 import CASAuthentication from 'express-cas-authentication';
 
@@ -10,6 +10,28 @@ import {
   CasAuthController,
   CasLogoutController,
 } from './controller';
+
+// Override the default CASAuthentication Logout function.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+CASAuthentication.prototype.logout = function logoutOverride(req: any, res: Response): void {
+  // Destroy the entire session if the option is set.
+  if (this.destroy_session) {
+    req.session.destroy((err: any) => {
+      if (err) {
+        /* eslint-disable-next-line no-console */
+        console.log(err);
+      }
+    });
+  } else { // Otherwise, just destroy the CAS session variables.
+    delete req.session[this.session_name];
+    if (this.session_info) {
+      delete req.session[this.session_info];
+    }
+  }
+  // Redirect the client back to the page the request was sent from. **OVERRIDE**
+  res.redirect('back');
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 /** Instantiate CASAuthentication */
 const cas = new CASAuthentication({

--- a/api/src/cas/route.ts
+++ b/api/src/cas/route.ts
@@ -1,16 +1,15 @@
 /** Node Imports */
-import express, { Response } from 'express';
+import express from 'express';
 import bodyParser from 'body-parser';
 
 /** Custom Imports */
 import {
+  cas,
   CasAPIController,
   CasUserController,
   CasAuthController,
   CasLogoutController,
 } from './controller';
-
-import cas from './controller'
 
 const jsonParser = bodyParser.json();
 const router = express.Router();

--- a/campusmap/src/app/App.tsx
+++ b/campusmap/src/app/App.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ReactElement } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
+import { AuthProvider } from 'campusmap/src/auth';
 import MapPage from 'campusmap/src/map';
 import NotFoundPage from 'campusmap/src/not-found';
 import LoginPage from 'campusmap/src/login';
@@ -16,32 +17,34 @@ import Footer from './Footer';
  * This component is rendered at the root element on the index page.
  */
 const App = (): ReactElement => (
-  <BrowserRouter>
-    <Header />
-    <main>
-      <Switch>
-        <Route exact path="/">
-          <MapPage targetId="mapContainer" />
-        </Route>
-        <Route path="/index">
-          <MapPage targetId="mapContainer" />
-        </Route>
-        <Route path="/search">
-          <SearchResultsPage />
-        </Route>
-        <Route path="/info/:id">
-          <InfoPage />
-        </Route>
-        <Route path="/user">
-          <LoginPage />
-        </Route>
-        <Route path="*">
-          <NotFoundPage />
-        </Route>
-      </Switch>
-    </main>
-    <Footer />
-  </BrowserRouter>
+  <AuthProvider>
+    <BrowserRouter>
+      <Header />
+      <main>
+        <Switch>
+          <Route exact path="/">
+            <MapPage targetId="mapContainer" />
+          </Route>
+          <Route path="/index">
+            <MapPage targetId="mapContainer" />
+          </Route>
+          <Route path="/search">
+            <SearchResultsPage />
+          </Route>
+          <Route path="/info/:id">
+            <InfoPage />
+          </Route>
+          <Route path="/user">
+            <LoginPage />
+          </Route>
+          <Route path="*">
+            <NotFoundPage />
+          </Route>
+        </Switch>
+      </main>
+      <Footer />
+    </BrowserRouter>
+  </AuthProvider>
 );
 
 export default App;

--- a/campusmap/src/app/Header/Header.tsx
+++ b/campusmap/src/app/Header/Header.tsx
@@ -1,29 +1,40 @@
 import * as React from 'react';
-import { ReactElement } from 'react';
+import { ReactElement, useContext } from 'react';
 import { Nav, Navbar } from 'react-bootstrap';
 
 // TODO: fix typescript import issue
 import logo from 'campusmap/public/images/logo.png';
 import SearchForm from 'campusmap/src/shared/SearchForm';
+import AuthContext from 'campusmap/src/auth';
 
-const Header = (): ReactElement => (
-  <header>
-    <Navbar variant="dark" bg="danger" expand="lg">
-      <Navbar.Brand href="/">
-        <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
-      </Navbar.Brand>
-      <Navbar.Toggle aria-controls="basic-navbar-nav" />
-      <Navbar.Collapse id="basic-navbar-nav">
-        <Nav className="mr-auto">
-          <Nav.Link href="/">Home</Nav.Link>
-          <Nav.Link href="/search">Browse</Nav.Link>
-          <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
-          <Nav.Link href="/user">Profile</Nav.Link>
-        </Nav>
-        <SearchForm />
-      </Navbar.Collapse>
-    </Navbar>
-  </header>
-);
+const Header = (): ReactElement => {
+  const user = useContext(AuthContext);
+  return (
+    <header>
+      <AuthContext.Consumer> 
+        {(user) => (
+          <Navbar variant="dark" bg="danger" expand="lg">
+            <Navbar.Brand href="/">
+              <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
+            </Navbar.Brand>
+            <Navbar.Toggle aria-controls="basic-navbar-nav" />
+            <Navbar.Collapse id="basic-navbar-nav">
+              <Nav className="mr-auto">
+                <Nav.Link href="/">Home</Nav.Link>
+                <Nav.Link href="/search">Browse</Nav.Link>
+                {(!user || JSON.stringify(user.casUser) === 'Not authenticated')
+                  ? <Nav.Link href={`/api/cas/logout?returnTo=${window.location.pathname}`}>Logout</Nav.Link>
+                  : <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
+                }
+                <Nav.Link href="/user">Profile</Nav.Link>
+              </Nav>
+              <SearchForm />
+            </Navbar.Collapse>
+          </Navbar>
+      )}
+      </AuthContext.Consumer>
+    </header>
+  );
+};
 
 export default Header;

--- a/campusmap/src/app/Header/Header.tsx
+++ b/campusmap/src/app/Header/Header.tsx
@@ -8,30 +8,34 @@ import SearchForm from 'campusmap/src/shared/SearchForm';
 import AuthContext from 'campusmap/src/auth';
 
 const Header = (): ReactElement => {
+  /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const user = useContext(AuthContext);
+  // console.log('user.casUser:', user.casUser);
+  // console.log('user.casUser === \'Not authenticated\':', user.casUser === 'Not authenticated');
   return (
     <header>
-      <AuthContext.Consumer> 
-        {(user) => (
-          <Navbar variant="dark" bg="danger" expand="lg">
-            <Navbar.Brand href="/">
-              <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
-            </Navbar.Brand>
-            <Navbar.Toggle aria-controls="basic-navbar-nav" />
-            <Navbar.Collapse id="basic-navbar-nav">
-              <Nav className="mr-auto">
-                <Nav.Link href="/">Home</Nav.Link>
-                <Nav.Link href="/search">Browse</Nav.Link>
-                {(!user || JSON.stringify(user.casUser) === 'Not authenticated')
-                  ? <Nav.Link href={`/api/cas/logout?returnTo=${window.location.pathname}`}>Logout</Nav.Link>
-                  : <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
-                }
-                <Nav.Link href="/user">Profile</Nav.Link>
-              </Nav>
-              <SearchForm />
-            </Navbar.Collapse>
-          </Navbar>
-      )}
+      <AuthContext.Consumer>
+        {/* eslint-disable-next-line no-shadow */
+          (user): ReactElement => (
+            <Navbar variant="dark" bg="danger" expand="lg">
+              <Navbar.Brand href="/">
+                <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
+              </Navbar.Brand>
+              <Navbar.Toggle aria-controls="basic-navbar-nav" />
+              <Navbar.Collapse id="basic-navbar-nav">
+                <Nav className="mr-auto">
+                  <Nav.Link href="/">Home</Nav.Link>
+                  <Nav.Link href="/search">Browse</Nav.Link>
+                  {(!user || user.casUser === 'Not authenticated')
+                    ? <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
+                    : <Nav.Link href={`/api/cas/logout?returnTo=${window.location.pathname}`}>Logout</Nav.Link>}
+                  <Nav.Link href="/user">Profile</Nav.Link>
+                </Nav>
+                <SearchForm />
+              </Navbar.Collapse>
+            </Navbar>
+          )
+        }
       </AuthContext.Consumer>
     </header>
   );

--- a/campusmap/src/app/Header/Header.tsx
+++ b/campusmap/src/app/Header/Header.tsx
@@ -10,8 +10,7 @@ import AuthContext from 'campusmap/src/auth';
 const Header = (): ReactElement => {
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   const user = useContext(AuthContext);
-  // console.log('user.casUser:', user.casUser);
-  // console.log('user.casUser === \'Not authenticated\':', user.casUser === 'Not authenticated');
+
   return (
     <header>
       <AuthContext.Consumer>
@@ -28,8 +27,12 @@ const Header = (): ReactElement => {
                   <Nav.Link href="/search">Browse</Nav.Link>
                   {(!user || user.casUser === 'Not authenticated')
                     ? <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
-                    : <Nav.Link href={`/api/cas/logout?returnTo=${window.location.pathname}`}>Logout</Nav.Link>}
-                  <Nav.Link href="/user">Profile</Nav.Link>
+                    : (
+                      <>
+                        <Nav.Link href="/user">Profile</Nav.Link>
+                        <Nav.Link href="/api/cas/logout">Logout</Nav.Link>
+                      </>
+                    )}
                 </Nav>
                 <SearchForm />
               </Navbar.Collapse>

--- a/campusmap/src/auth/AuthContext.tsx
+++ b/campusmap/src/auth/AuthContext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { PropsWithChildren, ReactElement } from 'react';
-import { Context, createContext, useState } from 'react'; 
+import { PropsWithChildren, ReactElement, useEffect, Context, createContext, useState } from 'react';
+
 import useAxios from 'axios-hooks';
 
 import { User } from 'campusmap/src/types';
@@ -8,24 +8,47 @@ import { User } from 'campusmap/src/types';
 const defaultUser: User = {
   casUser: 'Not authenticated',
   admin: false,
-}
+};
 
 export const AuthContext: Context<User> = createContext(defaultUser);
 
 export const AuthProvider = ({ children }: PropsWithChildren<{}>): ReactElement => {
   // const [user, setUser] = useState<User>(defaultUser);
+  const [isLoading, setLoading] = useState<boolean>(true);
 
-  const [{ data, loading }] = useAxios<User>({
+  const [{ data }, fetchUser] = useAxios<User>({
     url: '/api/cas/user',
-  }, { manual: false });
-  
-  // if (!loading) setUser(data);
+  }, { manual: true });
+
+  async function onLoad(): Promise<void> {
+    try {
+      await fetchUser();
+      // setUser(data);
+    } catch (e) {
+      // if (e !== 'No current user') {
+      //   alert(e);
+      // }
+    }
+
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    onLoad();
+  }, []);
+
+  // if (!isLoading) setUser(data);
 
   return (
-    <AuthContext.Provider value={data}>
-      {children}
-    </AuthContext.Provider>
+    <>{
+      !isLoading && (
+        <AuthContext.Provider value={data}>
+          {children}
+        </AuthContext.Provider>
+      )
+    }
+    </>
   );
-}
+};
 
 export default AuthContext;

--- a/campusmap/src/auth/AuthContext.tsx
+++ b/campusmap/src/auth/AuthContext.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { PropsWithChildren, ReactElement } from 'react';
+import { Context, createContext, useState } from 'react'; 
+import useAxios from 'axios-hooks';
+
+import { User } from 'campusmap/src/types';
+
+const defaultUser: User = {
+  casUser: 'Not Authenticated',
+  admin: false,
+}
+
+export const AuthContext: Context<User> = createContext(defaultUser);
+
+export const AuthProvider = ({ children }: PropsWithChildren<{}>): ReactElement => {
+  const [user, setUser] = useState<User>(defaultUser);
+
+  const [{ data, loading }] = useAxios<User>({
+    url: '/api/cas/user',
+  }, { manual: false });
+  
+  if (!loading) setUser(data);
+
+  return (
+    <AuthContext.Provider value={user}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export default AuthContext;

--- a/campusmap/src/auth/AuthContext.tsx
+++ b/campusmap/src/auth/AuthContext.tsx
@@ -6,23 +6,23 @@ import useAxios from 'axios-hooks';
 import { User } from 'campusmap/src/types';
 
 const defaultUser: User = {
-  casUser: 'Not Authenticated',
+  casUser: 'Not authenticated',
   admin: false,
 }
 
 export const AuthContext: Context<User> = createContext(defaultUser);
 
 export const AuthProvider = ({ children }: PropsWithChildren<{}>): ReactElement => {
-  const [user, setUser] = useState<User>(defaultUser);
+  // const [user, setUser] = useState<User>(defaultUser);
 
   const [{ data, loading }] = useAxios<User>({
     url: '/api/cas/user',
   }, { manual: false });
   
-  if (!loading) setUser(data);
+  // if (!loading) setUser(data);
 
   return (
-    <AuthContext.Provider value={user}>
+    <AuthContext.Provider value={data}>
       {children}
     </AuthContext.Provider>
   );

--- a/campusmap/src/auth/index.ts
+++ b/campusmap/src/auth/index.ts
@@ -1,0 +1,2 @@
+export { default } from './AuthContext';
+export * from './AuthContext';

--- a/campusmap/src/login/Login.tsx
+++ b/campusmap/src/login/Login.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { ReactElement, useContext } from 'react';
-import { Container, ProgressBar } from 'react-bootstrap';
-import useAxios from 'axios-hooks';
+import { Container } from 'react-bootstrap';
 
-import { User } from 'campusmap/src/types';
 import AuthContext from '../auth';
 
 /**

--- a/campusmap/src/login/Login.tsx
+++ b/campusmap/src/login/Login.tsx
@@ -1,29 +1,21 @@
 import * as React from 'react';
-import { ReactElement } from 'react';
+import { ReactElement, useContext } from 'react';
 import { Container, ProgressBar } from 'react-bootstrap';
 import useAxios from 'axios-hooks';
 
 import { User } from 'campusmap/src/types';
+import AuthContext from '../auth';
 
 /**
  * Top level component to control login feature.
  */
 const LoginPage = (): ReactElement => {
-  const [{ data, loading }] = useAxios<User>({
-    // Backend endpoint to confirm user login
-    url: '/api/cas/user',
-  }, { manual: false });
-
-  if (!loading) {
-    return (
-      <Container>
-        <code>{JSON.stringify(data)}</code>
-      </Container>
-    );
-  }
+  const user = useContext(AuthContext);
 
   return (
-    <ProgressBar animated variant="danger" now={100} />
+    <Container>
+      <code>{JSON.stringify(user)}</code>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Description
(Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.)
Very exciting update - these changes allow users to logout and be redirected back to CampusMap! Additionally, after user's login, the "Login" button changes to be "Logout". 

Fixes #156 

## Solution
(What did you do to fix this issue?)
With some magic and sorcery, we overrode the source code for the middleware cas.logout function and modified it to send a user back to whatever campusMap page they were on when they clicked logout. As for the header, we were unpackaging the response object incorrectly, so that was preventing the Login button to change to Logout.

## Known Issues
(Are there any new issues caused or exposed by your changes, or things you would like clarified before merging?)
Yes. If a user logs out from the profile page, they should be redirected to the home page. Instead, they are sent back to the profile page, which they shouldn't have access to anymore.


## Testing Procedures
(What should reviewers do to validate your changes? What steps should be taken and what is the expected outcome?)
You will have to pull this and run it locally since there is an issue with switching between prod and dev envs. So it may seem that something is wrong with the test deployment, but it is a nonissue.
Try your very best to break it.
Try logging in and logging out from many place in campus map. After every login, ensure that the correct RCS id shows on the profile page. And after every logout, ensure that the profile page is no longer available (it should not be in the header anymore :o) 

## Checklist for author
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
