### PR TITLE
Fix navigation refreshing entire page

### DIFF
--- a/campusmap/src/app/App.tsx
+++ b/campusmap/src/app/App.tsx
@@ -17,8 +17,8 @@ import Footer from './Footer';
  * This component is rendered at the root element on the index page.
  */
 const App = (): ReactElement => (
-  <AuthProvider>
-    <BrowserRouter>
+  <BrowserRouter>
+    <AuthProvider>
       <Header />
       <main>
         <Switch>
@@ -43,8 +43,8 @@ const App = (): ReactElement => (
         </Switch>
       </main>
       <Footer />
-    </BrowserRouter>
-  </AuthProvider>
+    </AuthProvider>
+  </BrowserRouter>
 );
 
 export default App;

--- a/campusmap/src/app/Footer/Footer.css
+++ b/campusmap/src/app/Footer/Footer.css
@@ -4,7 +4,7 @@ footer {
   z-index: 950;
 }
 
-a {
+footer a {
   text-decoration: none;
   color: inherit;
 }

--- a/campusmap/src/app/Header/Header.tsx
+++ b/campusmap/src/app/Header/Header.tsx
@@ -18,19 +18,19 @@ const Header = (): ReactElement => {
         {/* eslint-disable-next-line no-shadow */
           (user): ReactElement => (
             <Navbar variant="dark" bg="danger" expand="lg">
-              <Link component={Navbar.Brand} to="/">
+              <Link className="navbar-brand" to="/">
                 <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
               </Link>
               <Navbar.Toggle aria-controls="basic-navbar-nav" />
               <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="mr-auto">
-                  <Link component={Nav.Link} to="/">Home</Link>
-                  <Link component={Nav.Link} to="/search">Browse</Link>
+                  <Link className="nav-link" to="/">Home</Link>
+                  <Link className="nav-link" to="/search">Browse</Link>
                   {(!user || user.casUser === 'Not authenticated')
                     ? <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
                     : (
                       <>
-                        <Link component={Nav.Link} to="/user">Profile</Link>
+                        <Link className="nav-link" to="/user">Profile</Link>
                         <Nav.Link href="/api/cas/logout">Logout</Nav.Link>
                       </>
                     )}

--- a/campusmap/src/app/Header/Header.tsx
+++ b/campusmap/src/app/Header/Header.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { ReactElement, useContext } from 'react';
 import { Nav, Navbar } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
 
 // TODO: fix typescript import issue
 import logo from 'campusmap/public/images/logo.png';
@@ -17,19 +18,19 @@ const Header = (): ReactElement => {
         {/* eslint-disable-next-line no-shadow */
           (user): ReactElement => (
             <Navbar variant="dark" bg="danger" expand="lg">
-              <Navbar.Brand href="/">
+              <Link component={Navbar.Brand} to="/">
                 <img id="logo" src={logo} height="40px" alt="RPI CampusMap" />
-              </Navbar.Brand>
+              </Link>
               <Navbar.Toggle aria-controls="basic-navbar-nav" />
               <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="mr-auto">
-                  <Nav.Link href="/">Home</Nav.Link>
-                  <Nav.Link href="/search">Browse</Nav.Link>
+                  <Link component={Nav.Link} to="/">Home</Link>
+                  <Link component={Nav.Link} to="/search">Browse</Link>
                   {(!user || user.casUser === 'Not authenticated')
                     ? <Nav.Link href={`/api/cas?returnTo=${window.location.pathname}`}>Login</Nav.Link>
                     : (
                       <>
-                        <Nav.Link href="/user">Profile</Nav.Link>
+                        <Link component={Nav.Link} to="/user">Profile</Link>
                         <Nav.Link href="/api/cas/logout">Logout</Nav.Link>
                       </>
                     )}

--- a/campusmap/src/info/InfoPage.tsx
+++ b/campusmap/src/info/InfoPage.tsx
@@ -8,7 +8,7 @@ import {
   ProgressBar,
   Row,
 } from 'react-bootstrap';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import useAxios from 'axios-hooks';
 
 import { Comment, Location, Photo } from 'campusmap/src/types';
@@ -84,7 +84,7 @@ const InfoPage = (): ReactElement => {
                   <h2>{location.properties.name}</h2>
                   <p>{location.properties.description}</p>
                   <p>Also known as: {location.properties.nick}</p>
-                  <Button className="shadow" href={`/?location=${location.id}`} variant="danger">Show on Map</Button>
+                  <Link to={`/?location=${location.id}`}><Button className="shadow" variant="danger">Show on Map</Button></Link>
                 </Col>
                 <Col sm={6}>
                   <PhotoCarousel photos={photos} />

--- a/campusmap/src/info/InfoPage.tsx
+++ b/campusmap/src/info/InfoPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
+import Helmet from 'react-helmet';
 import {
   Button,
   Container,
@@ -65,6 +66,9 @@ const InfoPage = (): ReactElement => {
 
   return (
     <>
+      <Helmet>
+        <title>Info Page</title>
+      </Helmet>
       {loading && <ProgressBar animated variant="danger" now={100} />}
       {error && (
         <Container className="my-4">
@@ -77,6 +81,9 @@ const InfoPage = (): ReactElement => {
       )}
       {!loading && !error && (
         <>
+          <Helmet>
+            <title>{location.properties.name}</title>
+          </Helmet>
           <div className="py-4" style={{ backgroundColor: 'beige' }}>
             <Container>
               <Row id="infoSection">

--- a/campusmap/src/map/Map.tsx
+++ b/campusmap/src/map/Map.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useState,
 } from 'react';
+import Helmet from 'react-helmet';
 import useAxios from 'axios-hooks';
 import {
   Feature,
@@ -66,7 +67,12 @@ const Map = ({ targetId }: Props): ReactElement => {
   }, [createGeoJsonLayer, createPopup, campusMap, data, getLocationData, popupError]);
 
   return (
-    <div id={targetId} style={{ height: '100%' }} />
+    <>
+      <Helmet>
+        <title>RPI CampusMap</title>
+      </Helmet>
+      <div id={targetId} style={{ height: '100%' }} />
+    </>
   );
 };
 

--- a/campusmap/src/map/leaflet/mapUtils.tsx
+++ b/campusmap/src/map/leaflet/mapUtils.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+import { Link, StaticRouter } from 'react-router-dom';
+import { renderToString } from 'react-dom/server';
 import { Feature, FeatureCollection } from 'geojson';
 import {
   circleMarker,
@@ -25,20 +28,21 @@ export const onMapClick = (e: LeafletMouseEvent, popup: Popup, map: Map): void =
  * Populate html for a location popup on the map.
  * @param location The location to display information for.
 */
-const makePopupContent = (location: Location | Feature): string => {
-  if (location.properties) {
-    return (`
-    <a href="/info/${location.id}">
-      <div className="popup">
-        <h5>${location.properties.popupContent}</h5>
-        <img src="${location.properties.thumbnail}" alt="${location.properties.name}" width="100%"/>
-        <p>Nicknames: ${location.properties.nick}</p>
-      </div>
-    </a>
-  `);
-  }
-  return '';
-};
+const makePopupContent = (location: Location | Feature): string => (
+  location.properties
+    ? (renderToString(
+      <StaticRouter>
+        <Link to={`/info/${location.id}`}>
+          <div className="popup">
+            <h5>{location.properties.popupContent}</h5>
+            <img src={location.properties.thumbnail} alt={location.properties.name} width="100%" />
+            <p>Nicknames: {location.properties.nick}</p>
+          </div>
+        </Link>
+      </StaticRouter>
+    ))
+    : ''
+);
 
 /**
  * Create marker and set view to the given loaction on the map.

--- a/campusmap/src/not-found/NotFoundPage.tsx
+++ b/campusmap/src/not-found/NotFoundPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ReactElement } from 'react';
+import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 import { Container } from 'react-bootstrap';
 
@@ -7,25 +8,30 @@ import { Container } from 'react-bootstrap';
  * NotFoundPage element that specifies next steps when a page is not found.
  */
 const NotFoundPage = (): ReactElement => (
-  <Container className="my-4">
-    <h1>
-      We couldn&apos;t find the page you were looking for&nbsp;
-      <span role="img" aria-label="sad face">😢</span>
-    </h1>
-    <br />
-    <p>The URL may have been mistyped or the page may have moved:</p>
-    <ul>
-      <li>
-        Please try navigating back to the <Link to="/">homepage</Link> to find what you are looking for.
-      </li>
-      <li>
-        Alternatively you can&nbsp;
-        <a href="https://github.com/gaskij/rpicampusmap/issues/new" target="blank" rel="noopener noreferrer">
-          report a suspected issue.
-        </a>
-      </li>
-    </ul>
-  </Container>
+  <>
+    <Helmet>
+      <title>Page Not Found</title>
+    </Helmet>
+    <Container className="my-4">
+      <h1>
+        We couldn&apos;t find the page you were looking for&nbsp;
+        <span role="img" aria-label="sad face">😢</span>
+      </h1>
+      <br />
+      <p>The URL may have been mistyped or the page may have moved:</p>
+      <ul>
+        <li>
+          Please try navigating back to the <Link to="/">homepage</Link> to find what you are looking for.
+        </li>
+        <li>
+          Alternatively you can&nbsp;
+          <a href="https://github.com/gaskij/rpicampusmap/issues/new" target="blank" rel="noopener noreferrer">
+            report a suspected issue.
+          </a>
+        </li>
+      </ul>
+    </Container>
+  </>
 );
 
 export default NotFoundPage;

--- a/campusmap/src/search-results/SearchResultsPage.tsx
+++ b/campusmap/src/search-results/SearchResultsPage.tsx
@@ -12,18 +12,16 @@ import SearchResult from './SearchResult';
  * Top level component that renders the entire Search Results page.
  */
 const SearchResultsPage = (): ReactElement => {
-  const [params, queryString] = getParams();
+  const [params, query] = getParams();
 
   const [{ data, loading }] = useAxios<Location[]>({
-    url: `/api/search${queryString}`,
+    url: `/api/search${query}`,
   }, { manual: false });
-
-  const query = queryString ? `Search Results -- "${params.get('query')}"` : 'Browse All Locations';
 
   return (
     <>
       <Helmet>
-        <title>{query}</title>
+        <title>{query ? `Search Results -- "${params.get('query')}"` : 'Browse All Locations'}</title>
       </Helmet>
       <Container>
         <h5 className="my-4">{query}</h5>

--- a/campusmap/src/types/png.d.ts
+++ b/campusmap/src/types/png.d.ts
@@ -1,0 +1,1 @@
+declare module '*.png';


### PR DESCRIPTION
## Description
Currently the links on the header and various other places on the app use normal `<a>` tags, which do not work alongside React Router to provide swappable views. Instead, they should use the `<Link />` component provided by React Router.

## Solution
- Change `<a>` tags to `<Link />` where navigation within the app is happening. Any navigation away from the app still uses `<a>` tags.

## Known Issues
- Popups on the map still cause a whole page refresh due to issues with using the `<Link />` outside of the children of the top level `<BroswerRouter />`. Using the `<StaticRouter />` there now allows the Link to be used, but does not share history with the BrowserRouter.

## Testing Procedures
- Navigate to different screens on the app using the header or other links and verify that the whole screen does not refresh. You can usually tell by the loading spinner on the browser tab.

## Checklist for author
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
